### PR TITLE
refactor: avoid unnecessary cloning of strings

### DIFF
--- a/src/my_clippings_parser.rs
+++ b/src/my_clippings_parser.rs
@@ -45,15 +45,14 @@ fn tidy_note(note: &str) -> String {
     note.lines()
         .skip(1)
         .filter(|l| !is_useless_line(l))
-        .map(str::to_owned)
-        .collect::<Vec<String>>()
+        .collect::<Vec<&str>>()
         .join("\n")
 }
 
 fn is_useless_line(line: &str) -> bool {
-    line.starts_with(&*HIGHLIGHT_VALUE)
-        || line.starts_with(&*BOOKMARK_VALUE)
-        || line.starts_with(&*NOTE_VALUE)
+    line.starts_with(HIGHLIGHT_VALUE.as_str())
+        || line.starts_with(BOOKMARK_VALUE.as_str())
+        || line.starts_with(NOTE_VALUE.as_str())
         || line.is_empty()
 }
 


### PR DESCRIPTION
In the `tidy_note` function, use references to avoid cloning.

In the `is_useless_line` function, directly compare string slices to avoid unnecessary cloning.